### PR TITLE
Fixes MoOx/atom-smart-tab-name#7 for moving/dragging tabs

### DIFF
--- a/lib/smart-tab-name.coffee
+++ b/lib/smart-tab-name.coffee
@@ -115,8 +115,16 @@ class SmartTabName
         setTimeout processAllTabs, 10
       @disposables.add atom.workspace.onDidDestroyPaneItem ->
         setTimeout processAllTabs, 10
+      @disposables.add atom.workspace.onDidAddPane (pane)->
+        @disposables pane.onDidMoveItem ->
+          setTimeout processAllTabs, 10
       @disposables.add atom.commands.add 'atom-workspace',
       'smart-tab-name:toggle': @toggle
+
+      panes = atom.workspace.getPanes()
+      for pane in panes
+        @disposables pane.onDidMoveItem ->
+          setTimeout processAllTabs, 10
     log "loaded"
   toggle: =>
     @processed = processAllTabs(@processed)

--- a/lib/smart-tab-name.coffee
+++ b/lib/smart-tab-name.coffee
@@ -121,8 +121,7 @@ class SmartTabName
       @disposables.add atom.commands.add 'atom-workspace',
       'smart-tab-name:toggle': @toggle
 
-      panes = atom.workspace.getPanes()
-      for pane in panes
+      for pane in atom.workspace.getPanes()
         @disposables pane.onDidMoveItem ->
           setTimeout processAllTabs, 10
     log "loaded"


### PR DESCRIPTION
Re-process the tabs after they are moved, as they lose the smartness
