### PR TITLE
:bug: fix #11 SmartTabName when panes are split

### DIFF
--- a/lib/smart-tab-name.coffee
+++ b/lib/smart-tab-name.coffee
@@ -115,14 +115,14 @@ class SmartTabName
         setTimeout processAllTabs, 10
       @disposables.add atom.workspace.onDidDestroyPaneItem ->
         setTimeout processAllTabs, 10
-      @disposables.add atom.workspace.onDidAddPane (pane)->
-        @disposables pane.onDidMoveItem ->
+      @disposables.add atom.workspace.onDidAddPane (event) =>
+        @disposables.add event.pane.onDidMoveItem ->
           setTimeout processAllTabs, 10
       @disposables.add atom.commands.add 'atom-workspace',
       'smart-tab-name:toggle': @toggle
 
       for pane in atom.workspace.getPanes()
-        @disposables pane.onDidMoveItem ->
+        @disposables.add pane.onDidMoveItem ->
           setTimeout processAllTabs, 10
     log "loaded"
   toggle: =>


### PR DESCRIPTION
Change `pane` to `event.pane` since `onDidAddPane` callbacks take an
event as parameter.
Use fat-arrow `=>` to reference `@disposables` from the callback.
Dispose `onDidMoveItem` events with `@disposables.add` method.

Fix #11
Fix #10
